### PR TITLE
feat: Make header buttons transparent and blurred

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button';
   <div class="flex items-center gap-2">
     <ModeToggle client:load />
     <a href="/til/rss.xml">
-      <Button variant="outline" size="icon">
+      <Button variant="outline" size="icon" className="bg-transparent">
         <Rss />
       </Button>
     </a>

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -30,7 +30,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" className="bg-transparent">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>


### PR DESCRIPTION
Applied transparency to the background of the RSS and ModeToggle buttons in the header. This allows the header's backdrop-blur effect to show through, making the buttons visually consistent with the header's styling.

The `bg-transparent` Tailwind CSS class was added to these buttons to override their default outline variant background.