### PR TITLE
feat: ブログ記事に目次機能を追加

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+
+interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface TableOfContentsProps {
+  html: string;
+}
+
+export const TableOfContents: React.FC<TableOfContentsProps> = ({ html }) => {
+  const [headings, setHeadings] = useState<TocItem[]>([]);
+  const [activeId, setActiveId] = useState<string>('');
+
+  useEffect(() => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const headingElements = doc.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    
+    const items: TocItem[] = Array.from(headingElements).map((heading, index) => {
+      const id = heading.id || `heading-${index}`;
+      const level = parseInt(heading.tagName.substring(1));
+      return {
+        id,
+        text: heading.textContent || '',
+        level,
+      };
+    });
+    
+    setHeadings(items);
+  }, [html]);
+
+  useEffect(() => {
+    // Wait for the DOM to be fully rendered
+    const timeoutId = setTimeout(() => {
+      const postContent = document.querySelector('.znc');
+      if (!postContent) return;
+      
+      const headingElements = postContent.querySelectorAll('h1, h2, h3, h4, h5, h6');
+      const headingIds: string[] = [];
+      
+      headingElements.forEach((element, index) => {
+        if (!element.id) {
+          element.id = `heading-${index}`;
+        }
+        headingIds.push(element.id);
+      });
+
+      const handleScroll = () => {
+        const scrollPosition = window.scrollY + 100; // Adjusted offset
+        let currentActiveId = '';
+
+        for (const id of headingIds) {
+          const element = document.getElementById(id);
+          if (element) {
+            const rect = element.getBoundingClientRect();
+            const absoluteTop = rect.top + window.scrollY;
+            if (absoluteTop <= scrollPosition) {
+              currentActiveId = id;
+            }
+          }
+        }
+
+        // Check if we're at the bottom of the page
+        if (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 10) {
+          if (headingIds.length > 0) {
+            currentActiveId = headingIds[headingIds.length - 1];
+          }
+        }
+
+        if (currentActiveId) {
+          setActiveId(currentActiveId);
+        }
+      };
+
+      window.addEventListener('scroll', handleScroll);
+      handleScroll(); // Call once to set initial state
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [headings]);
+
+  const handleClick = (id: string) => {
+    const element = document.getElementById(id);
+    if (element) {
+      const offsetTop = element.offsetTop - 80;
+      window.scrollTo({
+        top: offsetTop,
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav className="h-full overflow-y-auto">
+      <h2 className="text-sm font-semibold mb-4 text-gray-900 dark:text-gray-100">
+        目次
+      </h2>
+      <ul className="space-y-2 text-sm">
+        {headings.map((heading) => (
+          <li
+            key={heading.id}
+            style={{ paddingLeft: `${(heading.level - 1) * 1}rem` }}
+          >
+            <button
+              onClick={() => handleClick(heading.id)}
+              className={`block w-full text-left py-1 px-2 rounded transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                activeId === heading.id
+                  ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 font-medium'
+                  : 'text-gray-600 dark:text-gray-400'
+              }`}
+            >
+              {heading.text}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};

--- a/src/pages/[date]/[id].astro
+++ b/src/pages/[date]/[id].astro
@@ -4,6 +4,7 @@ import lib from 'zenn-markdown-html';
 import { getAllPosts } from '../../lib/post';
 import Layout from '../../layouts/Layout.astro';
 import { Post } from '@/components/Post';
+import { TableOfContents } from '../../components/TableOfContents';
 
 type MarkdownOptions = {
   embedOrigin: string;
@@ -51,20 +52,25 @@ const html = markdownHtml(body, {
 ---
 
 <Layout title={title} tags={tags} body={body}>
-  <div class="px-4 pb-4 max-w-3xl m-auto">
-    <div class="pb-5 border-b-2 border-dashed dark:border-slate-500 mb-10">
-      <div>{date}</div>
-      <h1 class="font-bold text-4xl">{title}</h1>
-      <div class="flex flex-wrap">
-        {
-          tags.map(tag => (
-            <div class="bg-slate-300 dark:bg-slate-500 rounded-xl px-3 py-1 text-sm mr-2 mt-2">
-              {tag}
-            </div>
-          ))
-        }
+  <div class="relative">
+    <div class="px-4 pb-4 max-w-3xl m-auto">
+      <div class="pb-5 border-b-2 border-dashed dark:border-slate-500 mb-10">
+        <div>{date}</div>
+        <h1 class="font-bold text-4xl">{title}</h1>
+        <div class="flex flex-wrap">
+          {
+            tags.map(tag => (
+              <div class="bg-slate-300 dark:bg-slate-500 rounded-xl px-3 py-1 text-sm mr-2 mt-2">
+                {tag}
+              </div>
+            ))
+          }
+        </div>
       </div>
+      <Post html={html} />
     </div>
-    <Post html={html} />
+    <aside class="hidden xl:block fixed top-1/2 -translate-y-1/2 left-[calc(50%+26rem)] w-64 max-h-[80vh]">
+      <TableOfContents html={html} client:load />
+    </aside>
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- ブログ記事に目次（Table of Contents）コンポーネントを追加しました
- デスクトップ表示（xl breakpoint以上）で右サイドバーに固定表示されます
- スクロールに応じて現在読んでいるセクションがハイライトされます

## 実装内容
- 新しい`TableOfContents`コンポーネントを作成
  - 記事のHTMLから見出し（h1-h6）を抽出して目次を生成
  - スクロール位置を監視し、現在のセクションをハイライト
  - 目次項目をクリックすると該当セクションにスムーススクロール
- ブログ記事レイアウトの更新
  - 記事本文は中央カラムに維持
  - 目次は右側の余白スペースに固定配置（画面中央に対して垂直中央揃え）

## テストプラン
- [x] 記事ページで目次が正しく表示されることを確認
- [x] スクロール時に適切なセクションがハイライトされることを確認
- [x] 目次項目クリックで該当セクションにジャンプすることを確認
- [x] レスポンシブ対応（xlブレークポイント以下では非表示）を確認
- [x] ダークモードでの表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)