### PR TITLE
fix(types): add ambient module declaration for zenn-content-css

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,6 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+// zenn-content-css ships only a CSS entry with no type declarations,
+// so the side-effect import needs an ambient module to satisfy tsgo --noEmit.
+declare module "zenn-content-css";


### PR DESCRIPTION
## 背景

`main` の CI（`tsgo --noEmit`）が継続的に失敗していました。

```
src/components/Post.tsx(1,8): error TS2882: Cannot find module or type declarations for side-effect import of 'zenn-content-css'.
```

`zenn-content-css` は CSS エントリ（`lib/index.css`）のみを提供し型宣言を持たないため、副作用インポート `import 'zenn-content-css';` の型解決に失敗していました。

## 影響

`main` の CI が赤いため、Renovate の依存更新 PR（#123 minor/patch グループ）も CI を引き継いでマージ不能となり、依存関係の更新が停止していました。

## 変更

`src/env.d.ts` にアンビエントモジュール宣言を 1 行追加。

## 検証

`origin/main` 相当の worktree で全 CI ステップがグリーンになることを確認済み:
- `npx tsgo --noEmit` ✅
- `npm run lint` ✅（0 errors）
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)